### PR TITLE
Replace closure with parameter in remove method

### DIFF
--- a/Pod/Tests/Tests.swift
+++ b/Pod/Tests/Tests.swift
@@ -119,9 +119,10 @@ class Tests: XCTestCase {
     }
     XCTAssertTrue(Storage.existsAtPath(path))
 
-    Storage.removeAtPath(path) { error in
-      XCTAssertNil(error)
-    }
+    var error: NSError?
+    Storage.removeAtPath(path, &error)
+    XCTAssertNil(error)
+
     XCTAssertFalse(Storage.existsAtPath(path))
   }
 }

--- a/Source/Storage.swift
+++ b/Source/Storage.swift
@@ -119,13 +119,10 @@ public struct Storage {
     return fileManager.fileExistsAtPath(loadPath)
   }
 
-  public static func removeAtPath(path: URLStringConvertible, closure: (error: NSError?) -> Void) {
+  public static func removeAtPath(path: URLStringConvertible, _ error: NSErrorPointer? = nil) {
     let loadPath = Storage.buildPath(path)
 
-    var error: NSError?
-    fileManager.removeItemAtPath(loadPath, error: &error)
-
-    closure(error: error)
+    fileManager.removeItemAtPath(loadPath, error: error != nil ? error! : nil)
   }
 }
 


### PR DESCRIPTION
I think when you want to remove a file it's easier to write `Storage.removeAtPath(path, &error)` rather than `Storage.removeAtPath(path) { error in }`
